### PR TITLE
fix type definitions for new order and order status responses

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,27 +65,27 @@ declare module 'gdax' {
         size: string;
         product_id: string;
         side: 'buy' | 'sell';
-        stp: 'dc' | 'co' | 'cn' | 'cb';
         type: 'limit' | 'market' | 'stop';
         created_at: string;
         post_only: boolean;
         fill_fees: string;
         filled_size: string;
-        status: 'rejected' | 'received' | 'open' | 'done' | 'pending';
+        status: 'received' | 'rejected' | 'open' | 'done' | 'pending';
         settled: boolean;
         executed_value: string;
+        time_in_force: 'GTC' | 'GTT' | 'IOC' | 'FOK';
     }
 
     export interface OrderResult extends BaseOrderInfo {
-        time_in_force: 'GTC' | 'GTT' | 'IOC' | 'FOK';
-        status: 'rejected' | 'received' | 'open' | 'done';
+        stp: 'dc' | 'co' | 'cn' | 'cb';
     }
 
     export interface OrderInfo extends BaseOrderInfo {
         status: 'received' | 'open' | 'done' | 'pending';
-        funds: number;
-        specified_funds: number;
-        done_at: string;
+        funds?: number;
+        specified_funds?: number;
+        done_at?: string;
+        done_reason?: string;
     }
 
     export type PageArgs = {
@@ -224,7 +224,7 @@ declare module 'gdax' {
         cancelOrder(orderID: string, callback: callback<string[]>): void;
         cancelOrder(orderID: string): Promise<string[]>;
 
-        cancelAllOrders(args?: { product_id: string }, callback: callback<string[]>): void;
+        cancelAllOrders(args?: { product_id: string }, callback?: callback<string[]>): void;
         cancelAllOrders(args?: { product_id: string }): Promise<string[]>;
 
         getOrders(callback: callback<OrderInfo[]>): void;


### PR DESCRIPTION
These typedefs are more accurate. I based them on these orders:

### Order that hit the book
submission result:
```json
{
  "id": "9b335af9-3290-4f52-9d95-6e1e90b61299",
  "price": "0.01000000",
  "size": "0.01000000",
  "product_id": "ETH-BTC",
  "side": "buy",
  "stp": "dc",
  "type": "limit",
  "time_in_force": "GTC",
  "post_only": false,
  "created_at": "2018-04-07T19:58:09.868061Z",
  "fill_fees": "0.0000000000000000",
  "filled_size": "0.00000000",
  "executed_value": "0.0000000000000000",
  "status": "pending",
  "settled": false
}
```
status response:
```json
{
  "id": "9b335af9-3290-4f52-9d95-6e1e90b61299",
  "price": "0.01000000",
  "size": "0.01000000",
  "product_id": "ETH-BTC",
  "side": "buy",
  "type": "limit",
  "time_in_force": "GTC",
  "post_only": false,
  "created_at": "2018-04-07T19:58:09.868061Z",
  "fill_fees": "0.0000000000000000",
  "filled_size": "0.00000000",
  "executed_value": "0.0000000000000000",
  "status": "open",
  "settled": false
}
```
### Order executed immediately
submission result:
```json
{
  "id": "18b9308e-33b0-404d-a25d-0356b724cd1a",
  "price": "0.10000000",
  "size": "0.01000000",
  "product_id": "ETH-BTC",
  "side": "buy",
  "stp": "dc",
  "type": "limit",
  "time_in_force": "GTC",
  "post_only": false,
  "created_at": "2018-04-07T20:20:28.964275Z",
  "fill_fees": "0.0000000000000000",
  "filled_size": "0.00000000",
  "executed_value": "0.0000000000000000",
  "status": "pending",
  "settled": false
}
```
status result:
```
{
  "id": "18b9308e-33b0-404d-a25d-0356b724cd1a",
  "price": "0.10000000",
  "size": "0.01000000",
  "product_id": "ETH-BTC",
  "side": "buy",
  "type": "limit",
  "time_in_force": "GTC",
  "post_only": false,
  "created_at": "2018-04-07T20:20:28.964275Z",
  "done_at": "2018-04-07T20:20:28.967Z",
  "done_reason": "filled",
  "fill_fees": "0.0000016710000000",
  "filled_size": "0.01000000",
  "executed_value": "0.0005570000000000",
  "status": "done",
  "settled": true
}
```

Happy to look at more orders if necessary but this satisfies my team's use cases.

Thanks!